### PR TITLE
fix(resolve): use linked sequence action

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -254,7 +254,7 @@ async function resolveRef(opts, log) {
   try {
     const ow = openwhisk();
     const res = await ow.actions.invoke({
-      name: 'helix-services/resolve-git-ref@v1',
+      name: 'helix-services/resolve-git-ref@v1_link',
       blocking: true,
       result: true,
       params: opts,


### PR DESCRIPTION
this PR changes the action name for resolve-git to point to an extra sequence in order to solve #100 

the current `helix-services` package has:

```
  resolve-git-ref@v1_link  sequence -> /helix/helix-services/resolve-git-ref@v1
  resolve-git-ref@v1       sequence -> /helix/helix-services-private/resolve-git-ref@1.5.9
```