### PR TITLE
@ci link is useless

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "wsk-builder -v",
     "deploy": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json",
     "deploy-sequences": "wsk-builder --no-build -no-hints -l latest -l major -l minor",
-    "deploy-ci": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci"
+    "deploy-ci": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci$CIRCLE_BUILD_NUM"
   },
   "wsk": {
     "name": "helix-services-private/dispatch@${version}",


### PR DESCRIPTION
The `helix-services/dispatch@ci` automatically generated is useless since we do not know which version it refers too and might be overwritten by any other upcoming ci job.
Proposal is to replace it by `helix-services/publish@ciVERSION`
