### PR TITLE
feat(dispatch): try .html result for extension-less requests

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -116,18 +116,25 @@ function getPathInfos(urlPath, mount, indices, resolveDefault = ((a) => a)) {
   urlPath = urlPath.replace(/\/+/, '/');
   // check if url has extension, and if not create array of directory indices.
   const urls = [];
+  const extensionlessurls = [];
   if (urlPath.lastIndexOf('.') <= urlPath.lastIndexOf('/')) {
     // no extension, get the directory index
     indices.forEach((index) => {
       const indexPath = path.resolve(urlPath || '/', index);
       urls.push(indexPath);
     });
+
+    if (urlPath !== '/' && urlPath !== '') {
+      // allow extension-less requests, i.e. /foo becomes /foo.html
+      extensionlessurls.push(`${path.resolve(urlPath)}.html`);
+    }
   } else {
     urls.push(urlPath);
   }
 
   // add a default.* fallback
   const defaultUrls = urls.map(resolveDefault);
+  urls.push(...extensionlessurls);
   urls.push(...defaultUrls);
 
   // calculate the path infos for each url

--- a/test/fetchers.test.js
+++ b/test/fetchers.test.js
@@ -234,7 +234,7 @@ describe('testing fetchers.js', () => {
       path: '/example/dir',
     });
 
-    assert.equal(res.length, 9);
+    assert.equal(res.length, 12);
     logres(res);
   });
 
@@ -423,6 +423,12 @@ describe('testing path info resolution', () => {
         selector: '',
         ext: 'html',
         relPath: '/foo/index',
+      }, {
+        path: '/foo.html',
+        name: 'foo',
+        selector: '',
+        ext: 'html',
+        relPath: '/foo',
       },
       {
         path: '/foo/default.html',


### PR DESCRIPTION
see https://github.com/adobe/helix-home/issues/121

When requesting `/foo`, we will try (in order):

1. `/foo/index.html` (and all other configured directory indexes)
2. `/foo.html` (this is new)
3. `/foo/default.html`