### PR TITLE
chore(test): delete CI action after success

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
           command: npm run test-postdeploy
       - store_test_results:
           path: junit
+      - run:
+          name: Branch Undeployment
+          command: npm run undeploy-ci
 
 workflows:
   version: 2

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build": "wsk-builder -v",
     "deploy": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json",
     "deploy-sequences": "wsk-builder --no-build -no-hints -l latest -l major -l minor",
-    "deploy-ci": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci"
+    "deploy-ci": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci",
+    "undeploy-ci": "wsk-builder -v --delete --pkgVersion=ci$CIRCLE_BUILD_NUM"
   },
   "wsk": {
     "name": "helix-services/dispatch@${version}"


### PR DESCRIPTION
This adds a new behaviour to the circle ci post-deploy task, such as the `CI` version of the action is deleted after the post-deploy tests are successful.

see https://circleci.com/gh/adobe/helix-dispatch/1625 as example.

