### PR TITLE
fix(fetchers): remove README.html as directory index

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -361,7 +361,7 @@ function extractGithubToken(params = {}) {
  */
 function fetchers(params = {}) {
   const { __ow_logger: log } = params;
-  const dirindex = (params['content.index'] || 'index.html,README.html').split(',');
+  const dirindex = (params['content.index'] || 'index.html').split(',');
   const infos = getPathInfos(params.path || '/', params.rootPath || '', dirindex);
   const actioninfos = getPathInfos(params.path || '/', params.rootPath || '', dirindex, getDefault);
   const githubToken = extractGithubToken(params);

--- a/test/fetchers.test.js
+++ b/test/fetchers.test.js
@@ -87,7 +87,7 @@ describe('testing fetchers.js', () => {
   it('fetch nothing', async () => {
     const res = fetchers();
 
-    assert.equal(res.length, 9);
+    assert.equal(res.length, 6);
     logres(res);
   });
 
@@ -234,7 +234,7 @@ describe('testing fetchers.js', () => {
       path: '/example/dir',
     });
 
-    assert.equal(res.length, 9);
+    assert.equal(res.length, 6);
     logres(res);
   });
 


### PR DESCRIPTION
BREAKING CHANGE: As discussed in https://github.com/adobe/helix-home/issues/121#issuecomment-633903103 `README.html` is no longer a default directory index. Either rename your `README.md` to `index.md` or set the [`directoryIndex`](https://github.com/adobe/helix-shared/blob/master/docs/strains-definitions-anystrain-oneof-runtime-strain.md#directoryIndex) property in your strain config to `index.html,README.html` to restore the old behavior

fixes #268
