### PR TITLE
fix(dispatch): severe errors hidden by 404.html

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "deploy-ci": "wsk-builder -v --deploy --test=/_status_check/healthcheck.json --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci"
   },
   "wsk": {
+    "namespace": "helix",
     "name": "helix-services/dispatch@${version}"
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ async function executeActions(params) {
       });
   });
 
-  let fetch404Promise;
+  let fetch404Promise = Promise.resolve();
   try {
     // start the redirect process
     const redirectPromise = redirect(params, ow);
@@ -163,12 +163,13 @@ async function executeActions(params) {
 
     try {
       const resp404 = await fetch404Promise;
-      if (resp && resp.statusCode === 404) {
+      if (resp.statusCode === 404) {
         resp = resp404;
       }
     } catch (e) {
-      // ignore
-      log.info('no valid response could be fetched');
+      if (resp.statusCode === 404) {
+        log.info('no valid response could be fetched');
+      }
     }
     // check if X-Dispatch-NoCache header is in the request,
     // this will override the Cache-Control and Surrogate-Control

--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,41 @@ const { fetchers } = require('./fetchers');
 const { redirect, abortRedirect } = require('./redirects');
 
 /**
+ * Executes the fetcher promise and catches the errors. It determines the most severe error and
+ * throws it, unless it is a 404, in which case the function resolves with a 404 status code.
+ * @param {Logger} log logger
+ * @param {Promise} promise The promise of `executeActions`.
+ * @returns The result.
+ */
+async function deErrorify(log, promise) {
+  try {
+    return await promise;
+  } catch (e) {
+    let severe = e;
+    /* istanbul ignore next */
+    if (Array.isArray(e)) {
+      let worst = 0;
+      e.forEach((err, idx) => {
+        if (!err.statusCode || err.statusCode >= 500 || err.statusCode === 429) {
+          const id = err.actionOptions ? err.actionOptions.idx : '-';
+          log.error(`[${id}] ${err.message}`);
+          worst = idx;
+        }
+      });
+      severe = e[worst];
+    }
+    if (severe.statusCode === 404) {
+      return severe;
+    }
+    throw severe;
+  }
+}
+
+/**
  * Maximum number of internal redirects to follow before a loop is assumed
  */
 const MAX_REDIRECTS = 3;
+
 /**
  * This function dispatches the request to the content repository, the pipeline, and the static
  * repository. The preference order is:
@@ -55,6 +87,7 @@ async function executeActions(params) {
     const opts = {
       name: actionOptions.name,
       params: deepclone(actionOptions.params),
+      idx: idx + (actionOptions.idxOffset || 0),
     };
     Object.keys(opts.params).forEach((key) => {
       if (key.match(/^[A-Z0-9_]+$/)) {
@@ -64,35 +97,45 @@ async function executeActions(params) {
     if (opts.params.__ow_headers && opts.params.__ow_headers.authorization) {
       opts.params.__ow_headers.authorization = '[undisclosed secret]';
     }
-
-    log.infoFields(`[${idx}] Action: ${actionOptions.name}`, { actionOptions: opts });
+    log.infoFields(`[${opts.idx}] Action: ${actionOptions.name}`, { actionOptions: opts });
     return ow.actions.invoke(actionOptions)
       .then((reply) => {
         if (reply && reply.response && reply.response.result) {
           const res = reply.response.result;
           res.actionOptions = opts;
-          log.info(`[${idx}] ${reply.activationId} ${res.statusCode} ${res.errorMessage || ''}`);
+          log.info(`[${opts.idx}] ${reply.activationId} ${res.statusCode} ${res.errorMessage || ''}`);
           return actionOptions.resolve(res);
         } else {
           if (reply && reply.response) {
-            log.error(`[${idx}] provided a response but no result. Unknown state for ${reply.activationId}`, reply);
+            log.error(`[${opts.idx}] provided a response but no result. Unknown state for ${reply.activationId}`, reply);
           } else {
-            log.error(`[${idx}] did not provide a response. Unknown state for ${reply && reply.activationId ? reply.activationId : 'No activation id'}`, reply);
+            /* istanbul ignore next */
+            log.error(`[${opts.idx}] did not provide a response. Unknown state for ${reply && reply.activationId ? reply.activationId : 'No activation id'}`, reply);
           }
           return {
             statusCode: 500,
             body: 'Invalid state',
           };
         }
+      }).catch((err) => {
+        // eslint-disable-next-line no-param-reassign
+        err.actionOptions = opts;
+        throw err;
       });
   });
 
+  let fetch404Promise;
   try {
     // start the redirect process
     const redirectPromise = redirect(params, ow);
 
-    // start the fetching processes
-    const responsePromise = resolvePreferred(fetchers(params, log).map(invoker));
+    const tasks = fetchers(params, log);
+
+    // start the base fetching processes
+    const responsePromise = resolvePreferred(tasks.base.map(invoker));
+
+    // start the 404 fetching processes
+    fetch404Promise = resolvePreferred(tasks.fetch404.map(invoker));
 
     const { type, target } = await redirectPromise;
 
@@ -108,7 +151,6 @@ async function executeActions(params) {
       }
 
       log.info(`${type} redirect to ${target}`);
-      //
       return executeActions({
         ...params,
         redirects,
@@ -117,8 +159,17 @@ async function executeActions(params) {
     }
 
     // we explicitly (a)wait here, so we can catch a potential exception.
-    const resp = await responsePromise;
+    let resp = await deErrorify(log, responsePromise);
 
+    try {
+      const resp404 = await fetch404Promise;
+      if (resp && resp.statusCode === 404) {
+        resp = resp404;
+      }
+    } catch (e) {
+      // ignore
+      log.info('no valid response could be fetched');
+    }
     // check if X-Dispatch-NoCache header is in the request,
     // this will override the Cache-Control and Surrogate-Control
     // response headers to ensure no caching
@@ -132,38 +183,41 @@ async function executeActions(params) {
 
     return resp;
   } catch (e) {
-    let severe = e;
-
-    /* istanbul ignore next */
-    if (Array.isArray(e)) {
-      let worst = 0;
-      e.forEach((err, idx) => {
-        if (!err.statusCode || err.statusCode >= 500 || err.statusCode === 429) {
-          log.error(err.message);
-          worst = idx;
-        }
-      });
-      severe = e[worst];
+    try {
+      // we need to wait for the 404 requests, otherwise we have unhandled promise rejections
+      await fetch404Promise;
+    } catch {
+      // ignore
     }
 
-    if (severe.statusCode) {
-      if (severe.statusCode >= 500 || severe.statusCode === 429) {
-        log.error(`no valid response could be fetched: ${severe}`);
-      } else {
-        log.info(`no valid response could be fetched: ${severe}`);
-      }
+    /* istanbul ignore else */
+    if (e.statusCode) {
+      log.error(`no valid response could be fetched: ${e}`);
       return {
-        statusCode: severe.statusCode === 502 ? 504 : severe.statusCode,
+        statusCode: e.statusCode === 502 ? 504 : e.statusCode,
       };
     }
 
     // a fetchers `resolve` should never throw an exception but report a proper status response.
     // so we consider any exception thrown as application error and propagate it to openwhisk.
-    log.error(`error while invoking fetchers: ${severe}`);
+    /* istanbul ignore next */
+    log.error(`error while invoking fetchers: ${e}`);
+    /* istanbul ignore next */
     return {
-      error: `${String(severe.stack)}`,
+      error: `${String(e.stack)}`,
     };
   }
+}
+
+/**
+ * Runs the action. This extra step is added because the resulting status code is most of the
+ * time missing in the logs.
+ */
+async function run(params) {
+  const { __ow_logger: log } = params;
+  const result = await executeActions(params);
+  log.info('dispatch status code: ', result.statusCode);
+  return result;
 }
 
 /**
@@ -171,7 +225,7 @@ async function executeActions(params) {
  * @param params Action params
  * @returns {Promise<*>} The response
  */
-module.exports.main = wrap(executeActions)
+module.exports.main = wrap(run)
   .with(epsagon)
   .with(status)
   .with(logger.trace)

--- a/src/resolve-preferred.js
+++ b/src/resolve-preferred.js
@@ -11,6 +11,9 @@
  */
 
 const resolvePreferred = (promises) => new Promise((resolve, reject) => {
+  if (!promises.length) {
+    reject(new Error('unable to resolve preferred from empty array.'));
+  }
   const results = new Array(promises.length);
   let resolved = false;
   const unihandler = (idx, val, err) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ const OK_RESULT = () => Promise.resolve({
   },
 });
 
-const ERR_RESULT = () => Promise.resolve({
+const ERR_RESULT_404 = () => Promise.resolve({
   activationId: 'abcd-1234',
   response: {
     result: {
@@ -48,12 +48,6 @@ const ERR_RESULT = () => Promise.resolve({
     },
   },
 });
-
-/*
-const ERR_ERROR = () => {
-  throw new OpenWhiskError('POST https://runtime.adobe.io/api/v1/namespaces/helix-mini/actions/not_here?blocking=true Returned HTTP 404 (Not Found) --> "The requested resource does not exist."', {}, 404);
-};
-*/
 
 const SEVERE_RESULT = () => Promise.resolve({
   activationId: 'abcd-1234',
@@ -103,8 +97,44 @@ const ACTION_TIMEOUT_RESULT = () => Promise.resolve({
   },
 });
 
-const FAIL_RESULT = () => {
-  throw new Error('runtime failure.');
+const FAIL_RESULT_404 = (handle404) => async (resolver) => {
+  // only create 404 failure for html action.
+  if (resolver.name === 'default/html') {
+    const error = new Error('OpenWhiskError: POST https://runtime.adobe.io/api/v1/namespaces/acme/default/html Returned HTTP 404 (Not Found)');
+    error.error = {
+      code: '46qNNODdPtdUc0BEwMJzvVqOBDcv18uA',
+      error: 'The requested resource does not exist.',
+    };
+    error.statusCode = 404;
+    throw error;
+  } else if (resolver.params.path === '/404.html' && handle404) {
+    return OK_RESULT();
+  } else {
+    return ERR_RESULT_404();
+  }
+};
+
+const FAIL_RESULT_502 = (handle404) => async (resolver) => {
+  // only create 502 failure for html action.
+  if (resolver.name === 'default/html') {
+    const error = new Error('OpenWhiskError: POST https://runtime.adobe.io/api/v1/namespaces/acme/default/html Returned HTTP 502 (Bad Gateway)');
+    error.error = {
+      activationId: '1f92c2987a9a4eef92c2987a9abeefcf',
+      response: {
+        result: {
+          error: 'The action did not produce a valid response and exited unexpectedly.',
+        },
+        status: 'action developer error',
+        success: false,
+      },
+    };
+    error.statusCode = 502;
+    throw error;
+  } else if (resolver.params.path === '/404.html' && handle404) {
+    return OK_RESULT();
+  } else {
+    return ERR_RESULT_404();
+  }
 };
 
 const REF_RESULT = () => Promise.resolve({
@@ -214,7 +244,7 @@ describe('Index Tests', () => {
   });
 
   it('index returns action response when redirect cannot be determined', async () => {
-    redirResult = ERR_RESULT;
+    redirResult = ERR_RESULT_404;
 
     const result = await index({
       'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
@@ -322,7 +352,7 @@ describe('Index Tests', () => {
 
   it('index returns 404 response', async () => {
     const logger = createLogger('debug');
-    invokeResult = ERR_RESULT;
+    invokeResult = ERR_RESULT_404;
 
     const result = await index({
       'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
@@ -334,7 +364,8 @@ describe('Index Tests', () => {
       statusCode: 404,
     });
 
-    const output = JSON.stringify(logger.logger.buf);
+    const output = JSON.stringify(logger.logger.buf, null, 2);
+    // console.log(output);
     assert.ok(output.indexOf('no valid response could be fetched') >= 0);
   });
 
@@ -342,7 +373,7 @@ describe('Index Tests', () => {
     const logger = createLogger();
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return SEVERE_RESULT();
       }
@@ -366,7 +397,7 @@ describe('Index Tests', () => {
     const logger = createLogger();
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return TIMEOUT_RESULT();
       }
@@ -390,7 +421,7 @@ describe('Index Tests', () => {
     const logger = createLogger();
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return OVERLOAD_RESULT();
       }
@@ -415,7 +446,7 @@ describe('Index Tests', () => {
     refResult = OVERLOAD_ERROR;
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return OVERLOAD_ERROR();
       }
@@ -439,7 +470,7 @@ describe('Index Tests', () => {
     const logger = createLogger();
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return ACTION_TIMEOUT_RESULT();
       }
@@ -464,7 +495,7 @@ describe('Index Tests', () => {
     refResult = TIMEOUT_ERROR;
     invokeResult = (req) => {
       if (req.params.path === '/404.html') {
-        return ERR_RESULT();
+        return ERR_RESULT_404();
       } else {
         return TIMEOUT_ERROR();
       }
@@ -484,19 +515,78 @@ describe('Index Tests', () => {
     assert.ok(output.indexOf('no valid response could be fetched') >= 0);
   });
 
-  it('index produces application error when fetcher fails.', async () => {
+  it('index produces 404 when fetcher fails due to missing action (with 404 handler).', async () => {
     const logger = createLogger();
-    invokeResult = FAIL_RESULT;
+    invokeResult = FAIL_RESULT_404(true);
 
     const result = await index({
       'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
       'content.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
       __ow_logger: logger,
     });
-    assert.ok(result.error.indexOf('Error: runtime failure.\n    at FAIL_RESULT') >= 0);
 
-    const output = JSON.stringify(logger.logger.buf);
-    assert.ok(output.indexOf('error while invoking fetchers: Error: runtime failure.') >= 0);
+    // const output = JSON.stringify(logger.logger.buf, null, 2);
+    // console.log(output);
+
+    delete result.actionOptions;
+    assert.deepEqual(result, {
+      body: 'Hello, world.',
+      statusCode: 404,
+    });
+  });
+
+  it('index produces 404 when fetcher fails due to missing action (without 404 handler).', async () => {
+    const logger = createLogger();
+    invokeResult = FAIL_RESULT_404(false);
+
+    const result = await index({
+      'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      'content.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      __ow_logger: logger,
+    });
+
+    // const output = JSON.stringify(logger.logger.buf, null, 2);
+    // console.log(output);
+
+    delete result.actionOptions;
+    assert.deepEqual(result, {
+      statusCode: 404,
+    });
+  });
+
+  it('index produces 504 error when fetcher fails due to terminating action (with 404 handler).', async () => {
+    const logger = createLogger();
+    invokeResult = FAIL_RESULT_502(true);
+
+    const result = await index({
+      'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      'content.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      __ow_logger: logger,
+    });
+    const output = JSON.stringify(logger.logger.buf, null, 2);
+    // console.log(output);
+
+    assert.deepEqual(result, {
+      statusCode: 504,
+    });
+    assert.ok(output.indexOf('Error: OpenWhiskError: POST https://runtime.adobe.io/api/v1/namespaces/acme/default/html Returned HTTP 502 (Bad Gateway)') >= 0);
+  });
+
+  it('index produces 504 error when fetcher fails due to terminating action (without 404 handler).', async () => {
+    const logger = createLogger();
+    invokeResult = FAIL_RESULT_502(false);
+
+    const result = await index({
+      'static.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      'content.ref': '3e8dec3886cb75bcea6970b4b00783f69cbf487a',
+      __ow_logger: logger,
+    });
+    const output = JSON.stringify(logger.logger.buf, null, 2);
+    // console.log(output);
+    assert.deepEqual(result, {
+      statusCode: 504,
+    });
+    assert.ok(output.indexOf('Error: OpenWhiskError: POST https://runtime.adobe.io/api/v1/namespaces/acme/default/html Returned HTTP 502 (Bad Gateway)') >= 0);
   });
 
   it('index function w/o token does not instrument epsagon', async () => {

--- a/test/postdeploy.test.js
+++ b/test/postdeploy.test.js
@@ -38,7 +38,7 @@ describe('Running Post-Deployment Integration Tests', () => {
       }).catch((e) => {
         throw e;
       });
-  });
+  }).timeout(10000);
 
   it('Redirects work', async () => {
     // this is using the spreadsheet from https://adobe.sharepoint.com/:x:/r/sites/TheBlog/_layouts/15/doc2.aspx?sourcedoc=%7Bb20ba4a8-5040-40da-a19c-bad381543fb6%7D&action=editnew&cid=0c46f5e7-178b-4783-96d6-3f49edbe3043

--- a/test/resolve-preferred.test.js
+++ b/test/resolve-preferred.test.js
@@ -32,6 +32,10 @@ describe('Test custom Promise.race', () => {
     assert.ok(p.catch);
   });
 
+  it('race rejects empty tasks', async () => {
+    await assert.rejects(resolvePreferred([]), new Error('unable to resolve preferred from empty array.'));
+  });
+
   it('race resolves if only one promise succeeds', async () => {
     const p = await resolvePreferred([timeout(0, true)]);
     assert.equal(p, 'ok');


### PR DESCRIPTION
fixes #322

- splits the fetcher tasks into a `base` and `fetch404` group.
- moves the error detection from the reject array to own function `deErrorify()` and converts 404 error to non error response
- if `base` tasks produce a 404, only then consider the `fetch404` response.
- general log output improvements