### PR TITLE
fix(promises): add default handler for all unhandled promises

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   node10:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:15
         environment:
           NPM_CONFIG_PREFIX: "~/.npm-global"
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   node10:
     docker:
-      - image: circleci/node:15
+      - image: circleci/node:10
         environment:
           NPM_CONFIG_PREFIX: "~/.npm-global"
     working_directory: ~/repo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ commands:
           keys:
             - v3-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
       - run:
+          name: install npm 6.9.0
+          command: sudo npm -g install npm@6.9.0
+      - run:
           name: Installing Dependencies
           command: npm ci
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,6 @@ commands:
           keys:
             - v3-dependencies-{{ arch }}-{{ checksum "package-lock.json" }}
       - run:
-          name: install npm 6.9.0
-          command: sudo npm -g install npm@6.9.0
-      - run:
           name: Installing Dependencies
           command: npm ci
       - save_cache:

--- a/src/index.js
+++ b/src/index.js
@@ -218,7 +218,6 @@ async function executeActions(params) {
     } catch {
       // ignore
     }
-    
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -138,8 +138,7 @@ async function executeActions(params) {
       });
   });
 
-  const rejection = Promise.reject();
-  let fetch404Promise = rejection;
+  let fetch404Promise = Promise.reject().catch(() => {});
   try {
     const tasks = fetchers(ow, params, log);
 
@@ -214,17 +213,12 @@ async function executeActions(params) {
     };
   } finally {
     try {
-      // we need to wait for the dummy 404 request, otherwise we have unhandled promise rejections
-      await rejection;
-    } catch {
-      // ignore
-    }
-    try {
       // we need to wait for the 404 requests, otherwise we have unhandled promise rejections
       await fetch404Promise;
     } catch {
       // ignore
     }
+    
   }
 }
 

--- a/src/resolve-preferred.js
+++ b/src/resolve-preferred.js
@@ -11,8 +11,6 @@
  */
 
 const resolvePreferred = (promises) => new Promise((resolve, reject) => {
-  process.on('unhandledRejection', () => null);
-
   if (!promises.length) {
     reject(new Error('unable to resolve preferred from empty array.'));
   }

--- a/src/resolve-preferred.js
+++ b/src/resolve-preferred.js
@@ -11,6 +11,8 @@
  */
 
 const resolvePreferred = (promises) => new Promise((resolve, reject) => {
+  process.on('unhandledRejection', () => null);
+
   if (!promises.length) {
     reject(new Error('unable to resolve preferred from empty array.'));
   }

--- a/test/resolve-preferred.test.js
+++ b/test/resolve-preferred.test.js
@@ -30,6 +30,9 @@ describe('Test custom Promise.race', () => {
     const p = resolvePreferred([]);
     assert.ok(p.then);
     assert.ok(p.catch);
+    p.catch((err) => {
+      assert.equal(err.message, 'unable to resolve preferred from empty array.');
+    });
   });
 
   it('race rejects empty tasks', async () => {


### PR DESCRIPTION
@tripodsan in https://github.com/adobe/helix-dispatch/pull/353#issuecomment-711113626
> something changed and now uncaught promises exit the process. this is a problem, since in the fetcher race, we ignore the promises as soon as 1 successful. also see #326

I assume the CircleCI container got upgraded to [node 15](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#throw-on-unhandled-rejections---33021)

This is a brute force fix that restores the old behavior