### PR TITLE
feat: re-enable http/2

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -12,10 +12,6 @@
 /* eslint-disable no-param-reassign */
 const fetchAPI = require('@adobe/helix-fetch');
 
-// force HTTP/1 in order to avoid issues with long-lived HTTP/2 sessions
-// on azure/kubernetes based I/O Runtime
-process.env.HELIX_FETCH_FORCE_HTTP1 = true;
-
 function createFetchContext() {
   return process.env.HELIX_FETCH_FORCE_HTTP1
     ? fetchAPI.context({ alpnProtocols: [fetchAPI.ALPN_HTTP1_1] })

--- a/test/fetchers.test.js
+++ b/test/fetchers.test.js
@@ -11,6 +11,9 @@
  */
 
 /* eslint-env mocha */
+
+process.env.HELIX_FETCH_FORCE_HTTP1 = true;
+
 const assert = require('assert');
 const { Request, Response } = require('@adobe/helix-fetch');
 const nock = require('nock');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,8 @@
 
 /* eslint-env mocha */
 
+process.env.HELIX_FETCH_FORCE_HTTP1 = true;
+
 const assert = require('assert');
 const querystring = require('querystring');
 const { Request } = require('@adobe/helix-fetch');


### PR DESCRIPTION
As a precautionary measure HTTP/2 had been disabled in order to avoid issues related to the runtime migration to Azure. We've since re-implemented the http client (fetch) and now it's time to re-enable HTTP/2.